### PR TITLE
Return 500 and show error details if fixture(s) fail to load

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,8 +62,12 @@ module.exports = function setupTestFixtures(app, options) {
 
   Fixtures.setupFixtures = app.setupFixtures = function(opts, callback){
     if (!callback) callback = opts;
-    loadFixtures(app.models, options.fixturesPath, function(){
-      callback(null, 'setup complete');
+    loadFixtures(app.models, options.fixturesPath, function(errors){
+      if (errors) {
+        callback(errors);
+      } else {
+        callback(null, 'setup complete');
+      }
     });
   };
 

--- a/test/test-fixtures-invalid/Item.json
+++ b/test/test-fixtures-invalid/Item.json
@@ -1,0 +1,4 @@
+[
+  {"name": "First Item Name", "description": "Describes the first item."},
+  {"name": "Second Item Name", "description": "Describes the second item."}
+]

--- a/test/test-fixtures/Item.json
+++ b/test/test-fixtures/Item.json
@@ -1,4 +1,4 @@
 [
-  {"name": "First Item Name", "description": "Describes the first item."},
-  {"name": "Second Item Name", "description": "Describes the second item."}
+  {"name": "First Item Name", "requiredStuff": "asdf", "description": "Describes the first item."},
+  {"name": "Second Item Name", "requiredStuff": "asdf", "description": "Describes the second item."}
 ]


### PR DESCRIPTION
When using Loopback validation or middleware, the fixtures setup will currently fail silently and show a success message even if fixtures failed to load.

This PR changes the output of the `/api/fixtures/setup` call to return a `500` with an array of error messages for each fixture that failed if at least one fixture fails.

I've added tests and adjusted the test config to add tests for this new behavior.