### PR TITLE
Make error messaging configurable; add debugging + test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ Options:
 
   [Boolean] : Defines whether the fixture data should be loaded on startup. *(default: false)*
 
+ - `errorOnSetupFailure`
+
+  [Boolean] : Defines whether the API shows/throws an error when fixtures fail to load.  *(default: true)*
+
+  If **true**:
+    - Bad fixtures loaded on startup will cause the application to fail with an error.
+    - Bad fixtures loaded via the REST endpoint will return a `500` status code and an `error` object with details about the specific fixture failures.
+
+  If **false**:
+    - App will continue running (but log an error) if bad fixtures are loaded on startup
+    - App will return a 200 with no error details if bad fixtures are loaded when calling the fixture setup REST endpoint, but will log an error to the console.
+
  - `environments`
 
   [String/Array] : The name(s) of the environment(s) where the fixtures should be used. *(default: 'test')*

--- a/index.js
+++ b/index.js
@@ -3,22 +3,38 @@ var path = require('path');
 var async = require('async');
 var loopback = require('loopback');
 var merge = require('merge');
-
 var fixtures;
 var cachedFixtures;
 
+var DebugGenerator = require('debug');
+var debug = DebugGenerator('loopback:component:fixtures:');
+var debugSetup = DebugGenerator('loopback:component:fixtures:setup:verbose:');
+var debugTeardown = DebugGenerator('loopback:component:fixtures:teardown:verbose:');
+
 function loadFixtures(models, fixturesPath, callback) {
   function loadFixture(fixture, done){
+    debugSetup('Loading fixture', fixture);
+
     if (!cachedFixtures[fixture]) {
+      debugSetup('Fixture not cached; loading from disk');
       var fixtureData = require(fixturePath + fixture);
       cachedFixtures[fixture] = fixtureData;
     }
 
     var fixtureName = fixture.replace('.json', '');
-    models[fixtureName].create(cachedFixtures[fixture], done);
+    debugSetup('Loading fixtures for', fixtureName);
+    models[fixtureName].create(cachedFixtures[fixture], function(err) {
+      if (err) {
+        debugSetup('Error when attempting to add fixtures for', fixture);
+        debugSetup(err);
+      }
+
+      done(err);
+    });
   }
 
   if (!cachedFixtures) {
+    debugSetup('No cached fixtures; loading fixture files from', fixturePath);
     cachedFixtures = {}
     var fixturePath = path.join(process.cwd(), fixturesPath);
     var fixtureFolderContents = fs.readdirSync(fixturePath);
@@ -34,9 +50,12 @@ module.exports = function setupTestFixtures(app, options) {
 
   options = merge({
     loadFixturesOnStartup: false,
+    errorOnSetupFailure: false,
     environments: 'test',
-    fixturesPath: '/server/test-fixtures/'
+    fixturesPath: '/server/test-fixtures/',
   }, options);
+
+  debug('Loading fixtures with options', options);
 
   var environment = app.settings && app.settings.env
     ? app.settings.env : process.env.NODE_ENV;
@@ -46,12 +65,18 @@ module.exports = function setupTestFixtures(app, options) {
     : environment === options.environments;
 
   if (!match) {
+    debug('Skipping fixtures because environment', environment, 'is not in options.enviornments');
     return;
   }
 
   if (options.loadFixturesOnStartup){
     loadFixtures(app.models, options.fixturesPath, function(err){
-      if (err) console.log(err);
+      if (err) {
+        debug('Error when loading fixtures on startup:', err);
+      }
+      if (err && options.errorOnSetupFailure) {
+        throw new Error('Failed to load fixtures on startup:', err);
+      }
     });
   }
 
@@ -61,22 +86,28 @@ module.exports = function setupTestFixtures(app, options) {
   });
 
   Fixtures.setupFixtures = app.setupFixtures = function(opts, callback){
+    /* istanbul ignore else */
     if (!callback) callback = opts;
+    debug('Loading fixtures');
     loadFixtures(app.models, options.fixturesPath, function(errors){
       if (errors) {
-        callback(errors);
-      } else {
-        callback(null, 'setup complete');
+        debug('Fixtures failed to load:', errors);
       }
+      if (errors && options.errorOnSetupFailure) {
+        return callback(errors);
+      }
+      callback(null, 'setup complete');
     });
   };
 
   Fixtures.teardownFixtures = app.teardownFixtures = function(opts, callback){
+    /* istanbul ignore else */
     if (!callback) callback = opts;
-
+    debugTeardown('Tearing down fixtures for', Object.keys(app.datasources));
     var dataSourceNames = Object.keys(app.datasources);
 
     var migrateDataSource = function(dataSourceName, done){
+      debugTeardown('Tearing down fixtures for', dataSourceName);
       var dataSource = app.datasources[dataSourceName];
 
       if (Array.isArray(fixtures)) {
@@ -94,15 +125,37 @@ module.exports = function setupTestFixtures(app, options) {
         var modelNamesBothCases = modelNames.concat(modelNamesLower);
 
         var remigrateModel = function(model, done) {
-          dataSource.automigrate(model, done);
+          debugTeardown('Dropping model', model, 'from', dataSourceName);
+          dataSource.automigrate(model, function(err) {
+            if (err) {
+              debugTeardown('Error when attempting to automigrate', model);
+              debugTeardown(err);
+            } else {
+              debugTeardown('Successfully migrated', model);
+            }
+            done(err);
+          });
         }
+
         async.each(modelNamesBothCases, remigrateModel, done);
       } else {
-        dataSource.automigrate(done);
+        debugTeardown('Dropping all models for', dataSourceName);
+        dataSource.automigrate(function() {
+          debugTeardown('Returning fixture teardown success (ignoring success/fail messages)');
+          done();
+        });
       }
     };
 
-    async.each(dataSourceNames, migrateDataSource, function(){
+    debug('Tearing down data sources:', dataSourceNames)
+    async.each(dataSourceNames, migrateDataSource, function(errors){
+      if (errors) {
+        debug('Failed to tear down fixtures:', errors);
+        debug('Note that errors here does not necessarily mean the teardown');
+        debug('itself failed; you should look at your database to ensure that');
+        debug('your collections/tables are now empty.');
+      }
+      debug('Returning fixture teardown success message');
       callback(null, 'teardown complete');
     });
   };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Component for handling fixture data for client side tests",
   "main": "index.js",
   "scripts": {
-    "test": "NODE_ENV=test mocha ./test/**/*.js"
+    "test": "npm run cover && npm run assert_coverage_thresholds",
+    "cover": "NODE_ENV=test istanbul cover node_modules/.bin/_mocha -- test",
+    "assert_coverage_thresholds": "istanbul check-coverage --statement -90 --branch -85 --function 100 --lines 90"
   },
   "repository": {
     "type": "git",
@@ -20,12 +22,14 @@
   "license": "MIT",
   "dependencies": {
     "async": "^1.4.2",
+    "debug": "^2.2.0",
     "loopback": "^2.22.2",
     "loopback-datasource-juggler": "^2.41.0",
     "merge": "^1.2.0"
   },
   "devDependencies": {
     "chai": "^3.3.0",
+    "istanbul": "^0.4.4",
     "mocha": "^2.3.3",
     "supertest": "^1.1.0"
   }


### PR DESCRIPTION
To prevent a breaking change from v1.0 to v1.0.1, the 500 error response should be off by default (and configurable to be turned on).  This PR will enable the following if the `errorOnSetupFailure` is on:

- If loading fixtures on startup, the app will exit with an error.
- If loading fixtures via REST endpoint, the app will return a 500 and error details.

If the flag is off (default):

- If loading fixtures on startup, an error will be logged but the app will continue
- If loading fixtures via REST endpoint, the app will return 200 but error details will be logged.

Debugging uses the `debug` package, which allows debug messages to be turned on/off via the `DEBUG=loopback:component:fixtures:*` environment variable.

Istanbul has been added to calculate and assert test coverage.  Current coverage is at:
- 100% statements
- 95% branches (ignoring some if/else branches that manage parameters at the start of the fixture methods)
- 100% function coverage
- 100% line coverage