### PR TITLE
Fix issue with fixtures model appearing twice on app.models

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ module.exports = function setupTestFixtures(app, options) {
     : environment === options.environments;
 
   if (!match) {
-    debug('Skipping fixtures because environment', environment, 'is not in options.enviornments');
+    debug('Skipping fixtures because environment', environment, 'is not in options.environments');
     return;
   }
 
@@ -80,7 +80,7 @@ module.exports = function setupTestFixtures(app, options) {
     });
   }
 
-  var Fixtures = app.model('fixtures', {
+  var Fixtures = app.model('Fixtures', {
     dataSource: false,
     base: 'Model'
   });


### PR DESCRIPTION
The model that gets created got added twice to app.models:

- app.models.fixtures
- app.models.Fixtures

Renaming this definition seems to fix the issue, without further impact.

The way I tested this was to do `console.log(Object.keys(app.models))` after loading the app. The result was the following array:

`[ 'User', 'AccessToken', 'ACL', 'RoleMapping', 'Role', 'fixtures', 'Fixtures' ]`.

After this patch it only appears once as `Fixtures`.  